### PR TITLE
initial version of migration guide post

### DIFF
--- a/_posts/2021-06-01-migration-v1-v2.md
+++ b/_posts/2021-06-01-migration-v1-v2.md
@@ -1,0 +1,130 @@
+---
+layout: post
+title: "Apicurio Registry 2.0.0.Final Migration Guide"
+date:   2021-06-01 12:00:00
+author: fabian
+categories: registry guide
+---
+
+Apicurio Registry 2.x release is our latest and greatest release to date. It has plenty new features but it also comes with some breaking changes from the previous
+1.3.X release. In this document we explore the process to migrate to Apicurio Registry 2.X
+
+---
+
+# Apicurio Registry 2.0.0.Final Migration Guide
+
+Apicurio Registry 2.x release is our latest and greatest release to date. It has plenty new features but it also comes with some breaking changes from the previous
+1.3.X release.
+
+Because of the breaking changes there is no automatic upgrade and instead a migration process is required, but no worries, the process is not hard.
+
+## Breaking changes
+
+There are three major changes in this release that need to be taken into account in order to proceed with a migration. 
+
+New storage options, this impacts your current Apicurio Registry deployment. In Apicurio Registry 1.3.X we had 3 storage options (streams, jpa and infinispan), now in
+Apicurio Registry 2.X we droped all of them but provided new and improved alternatives that we believe will be better for the project in the long term, allowing to have more robust and performant deployments while at the same time being reasonabily maintainable. The new storage options are (sql and kafkasql), there is a third one (mem) that is not suitable for production workloads. This document will not cover the process of deploying Apicurio Registry 2.X, you can find more information [here](https://www.apicur.io/registry/docs/apicurio-registry/2.0.0.Final/getting-started/assembly-installing-registry-storage-openshift.html)
+
+New REST API, we changed the REST API layout to ensure better long term maintainability and because we refactored our API to have support for artifact groupings. Apicurio Registry still supports the original REST API now known as `v1` and the various compatibility APIs we already support (confluent compat, ibm compat) and a new API that implements the Schema Registry spec provided within CNCF Cloud Events spec.
+
+Refactored SerDes libraries, now available as three different maven modules (one for each data format)
+
+## Migration
+
+The migration from Apicurio Registry 1.3.X to 2.X requires you to move the data from one registry to another along with a review of your applications that interact with the registry in order to update the configuration of your applications to accomadate to the new requirements.
+
+### Data Migration
+
+The process of data migration to Apicurio Registry 2.X will require you to export all the data from your 1.3.X deployment and import it to the new 2.X based deployment.
+
+Data migration is a critical step in the migration to Apicurio Registry 2.X if you are using the registry as a schema registry for Kafka applications and if you are using our Kafka SerDes libraries, every kafka message carries the global identifier for the schema stored in Apicurio Registry. It's critical that this identifier is kept between registry upgrades and data migrations.
+
+For that purpose Apicurio Registry 2.X provides a new import/export API to bulk import or export all the data from your registry deployment. This API guarantees that all the identifiers are kept when importing the data from your old registry. The export API works by downloading a custom zip file containing all the information of your artifacts. The import API accepts that zip file.
+
+Apicurio Registry 1.3.X does not provide an import/export API but with the 2.X release we provided a export tool compatible with Apicurio Registry 1.3.X that allows you to export a zip file which then can be imported to your 2.X registry.
+
+This export tool can be found [here](https://github.com/Apicurio/apicurio-registry/tree/2.0.x/utils/exportV1). It is a java application meant to be invoked from the command line.
+
+The migration steps for moving all your data from one version to another would be like this:
+
+**Pre-requisites**: having both a running Apicurio Registry instance for the version 1.3.X and 2.X.
+
+1 - Export all the data from Apicurio Registry 1.3.X using the `exportV1` tool. This will generate a `registry-export.zip` file in your current directory.
+
+```
+java -jar apicurio-registry-utils-exportV1-2.0.0-SNAPSHOT-runner.jar http://old-registry.my-company.com/api
+```
+
+2 - Import the zip file to Apicurio Registry 2.X using the import API. Extended documentation on this API can be found [here](https://www.apicur.io/registry/docs/apicurio-registry/2.0.0.Final/getting-started/assembly-managing-registry-artifacts-api.html#exporting-importing-using-rest-api)
+
+```
+curl -X POST "http://new-registry.my-company.com/apis/registry/v2/admin/import" \
+  -H "Accept: application/json" -H "Content-Type: application/zip" \
+  --data-binary @registry-export.zip
+```
+
+3 - Check the all the artifacts are now imported to the newest registry. Run this two commands and compare the count field.
+
+```
+curl "http://old-registry.my-company.com/api/search/artifacts"
+```
+
+```
+curl "http://new-registry.my-company.com/apis/registry/v2/search/artifacts"
+```
+
+
+### Application Migration
+
+TL.DR. if you are using the SerDes libraries, you need to change the maven dependencies
+
+In Apicurio Registry 1.3.X the SerDes libraries were provided all with just one maven dependency
+```
+<dependency>
+    <groupId>io.apicurio</groupId>
+    <artifactId>apicurio-registry-utils-serde</artifactId>
+    <version>1.3.2.Final</version>
+</dependency>
+```
+
+In Apicurio Registry 2.X this has been changed, and the SerDes libraries have been splitted in three maven dependencies, one for each supported data format: `avro`, `protobuf` and `json schema`.
+
+```
+<dependency>
+    <groupId>io.apicurio</groupId>
+    <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
+    <version>2.0.0.Final</version>
+</dependency>
+<dependency>
+    <groupId>io.apicurio</groupId>
+    <artifactId>apicurio-registry-serdes-protobuf-serde</artifactId>
+    <version>2.0.0.Final</version>
+</dependency>
+<dependency>
+    <groupId>io.apicurio</groupId>
+    <artifactId>apicurio-registry-serdes-jsonschema-serde</artifactId>
+    <version>2.0.0.Final</version>
+</dependency>
+```
+
+You have to take into account this changes in the maven dependencies, and update your applications accordingly.
+
+The refactored SerDes libraries also include some changes in the configuration properties, you can find more information [here](https://www.apicur.io/registry/docs/apicurio-registry/2.0.0.Final/getting-started/assembly-using-kafka-client-serdes.html) , and you can find plenty of examples using Apicurio Registry 2.0.0.Final SerDes libraries [here](https://github.com/Apicurio/apicurio-registry-examples/tree/2.0.x)
+
+But the most important thing you have to change is the registry url config property, you have to change from pointing to the old API path to the new one. Example:
+
+Old:
+```
+props.putIfAbsent(AbstractKafkaSerDe.REGISTRY_URL_CONFIG_PARAM, "http://localhost:8080/api");
+```
+
+New:
+```
+props.putIfAbsent(SerdeConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v2");
+```
+
+---
+
+This is the most important things to take into account when doing the update to Apicurio Registry 2.0.0.Final. The process is not complex but there are some critical steps that, thanks to our APIs and tooling, should be no problem.
+
+As always, if you have any suggestions or encounter any problem feel free to contact the team by [filling an issue in GitHub](https://github.com/Apicurio/apicurio-registry/issues)

--- a/_posts/2021-06-01-migration-v1-v2.md
+++ b/_posts/2021-06-01-migration-v1-v2.md
@@ -6,8 +6,7 @@ author: fabian
 categories: registry guide
 ---
 
-Apicurio Registry 2.x release is our latest and greatest release to date. It has plenty of new features but it also comes with some breaking changes from the previous
-1.3.x release. In this post we will explore the process to migrate data from Apicurio Registry 1.3.x to Apicurio Registry 2.x.
+Apicurio Registry 2.x release is our latest and greatest release to date. It has plenty of new features but it also comes with some breaking changes from the previous 1.3.x release. In this post we will explore the process to migrate data from Apicurio Registry 1.3.x to Apicurio Registry 2.x.
 
 ---
 
@@ -20,18 +19,18 @@ Because of the breaking changes between 1.3.x and 2.x, there is no automatic upg
 There are three major changes in this release that need to be taken into account in order to proceed with a migration.
 
 ### New storage options
-This impacts your current Apicurio Registry deployment. In Apicurio Registry 1.3.x we had 3 storage options (streams, jpa and infinispan).  Now in
-Apicurio Registry 2.x we dropped all of them but provided new and improved alternatives that we believe will be better for the project in the long term.  These new storages allow for more robust and performant deployments while at the same time being more maintainable. The new storage options are `sql` and `kafkasql`).  There is a third one `mem` that is not suitable for production workloads. This document will not cover the process of deploying Apicurio Registry 2.x, you can find more information [here](https://www.apicur.io/registry/docs/apicurio-registry/2.0.0.Final/getting-started/assembly-installing-registry-storage-openshift.html)
+This impacts your current Apicurio Registry deployment. In Apicurio Registry 1.3.x we had 3 storage options (`streams`, `jpa` and `infinispan`).  Now in
+Apicurio Registry 2.x we dropped all of them but provided new and improved alternatives that we believe will be better for the project in the long term.  These new storages allow for more robust and performant deployments while at the same time being more maintainable. The new storage options are `sql` and `kafkasql`).  There is a third one `mem` that is not suitable for production workloads. This document will not cover the process of deploying Apicurio Registry 2.x, you can find more details in the [Apicurio Registry user documentation](https://www.apicur.io/registry/docs/apicurio-registry/2.0.0.Final/getting-started/assembly-installing-registry-storage-openshift.html)
 
 ### New REST API
-We changed the REST API layout to ensure better long term maintainability and because we refactored our API to have support for artifact groupings. Apicurio Registry still supports the original REST API (now known as `v1`) and the various compatibility APIs we already supported (confluent compat, ibm compat).  Additionally, Registry now also implements the Schema Registry spec provided within the CNCF Cloud Events spec.
+We changed the REST API layout to ensure better long term maintainability and because we refactored our API to have support for artifact groupings. Apicurio Registry still supports the original REST API (now known as `v1`) and the various compatibility APIs we already supported (for example, Confluent and IBM schema registry APIs).  Additionally, Apicurio Registry now also implements the Schema Registry spec provided within the CNCF Cloud Events spec.
 
 ### Refactored SerDes libraries
-The Serializer and Deserializer classes are now available as three different maven modules (one for each data format).  This makes it possible to use just the one you want without pulling in a bunch of transitive dependencies that you don't care about.
+The Serializer and Deserializer classes are now available as three different Maven modules (one for each data format). This makes it possible to use just the one you want without pulling in a bunch of transitive dependencies that you don't care about.
 
 ## Migration
 
-The migration from Apicurio Registry 1.3.x to 2.x requires you to move the data from your old registry to another along with a review of your applications that interact with the registry in order to update the configuration of your applications to accomadate to the new requirements.
+The migration from Apicurio Registry 1.3.x to 2.x requires you to move the data in your existing registry to a new registry. You must also review your applications that interact with the registry and update their configuration to meet the new requirements.
 
 ### Data Migration
 
@@ -39,15 +38,15 @@ The process of data migration to Apicurio Registry 2.x will require you to expor
 
 Data migration is a critical step in the migration to Apicurio Registry 2.x if you are using the registry as a schema registry for Kafka applications, because every Kafka message carries the global identifier for the schema stored in Apicurio Registry. It is critical that this identifier is kept between registry upgrades via data migration.
 
-For that purpose Apicurio Registry 2.x provides a new import/export API to bulk import or export all the data from your registry deployment. This API guarantees that all the identifiers are kept when importing the data from your old registry. The export API works by downloading a custom zip file containing all the information of your artifacts. The import API accepts that zip file, loading all of the artifacts into the registry in a single batch.
+For that purpose Apicurio Registry 2.x provides a new import/export API to bulk import or export all the data from your registry deployment. This API guarantees that all the identifiers are kept when importing the data from your existing registry. The export API works by downloading a custom zip file containing all the information of your artifacts. The import API accepts that zip file, loading all of the artifacts into the registry in a single batch.
 
-Apicurio Registry 1.3.x does not provide an import/export API but with the 2.x release we provided an export tool compatible with Apicurio Registry 1.3.x that allows you to export a compatible zip file which then can be imported to your 2.x registry.  This special export tool uses common existing APIs to export all of the content in the registry.  It is less performant than the built-in export API we have introduced in 2.x, and so should only be used when exporting from a 1.3.x registry.
+Apicurio Registry 1.3.x does not provide an import/export API, but with the 2.x release we provided an export tool compatible with Apicurio Registry 1.3.x that allows you to export a compatible zip file, which can be imported to your 2.x registry. This special export tool uses common existing APIs to export all of the content in the registry. It is less performant than the built-in export API we have introduced in 2.x, and so should only be used when exporting from a 1.3.x registry.
 
-This export tool can be found [here](https://github.com/Apicurio/apicurio-registry/tree/2.0.x/utils/exportV1). It is a java application meant to be invoked from the command line.
+This export tool is available from the [Apicurio Registry GitHub project](https://github.com/Apicurio/apicurio-registry/tree/2.0.x/utils/exportV1). It is a java application meant to be invoked from the command line.
 
 The migration steps for moving all your data from one version to another:
 
-**Pre-requisites**: having running Apicurio Registry instances for both the version 1.3.x server (exporting from) and the new 2.x server (importing to).
+**Prerequisites**: Have running Apicurio Registry instances for both the version 1.3.x server (exporting from) and the new 2.x server (importing to).
 
 1. Export all the data from Apicurio Registry 1.3.x using the `exportV1` tool. This will generate a `registry-export.zip` file in your current directory.
 
@@ -55,7 +54,7 @@ The migration steps for moving all your data from one version to another:
 java -jar apicurio-registry-utils-exportV1-2.0.0-SNAPSHOT-runner.jar http://old-registry.my-company.com/api
 ```
 
-2 - Import the zip file to Apicurio Registry 2.x using the import API. Extended documentation on this API can be found [here](https://www.apicur.io/registry/docs/apicurio-registry/2.0.0.Final/getting-started/assembly-managing-registry-artifacts-api.html#exporting-importing-using-rest-api)
+2. Import the zip file to Apicurio Registry 2.x using the import API. You can find more details in the [Apicurio Registry user documentation](https://www.apicur.io/registry/docs/apicurio-registry/2.0.0.Final/getting-started/assembly-managing-registry-artifacts-api.html#exporting-importing-using-rest-api)
 
 ```
 curl -X POST "http://new-registry.my-company.com/apis/registry/v2/admin/import" \
@@ -63,7 +62,7 @@ curl -X POST "http://new-registry.my-company.com/apis/registry/v2/admin/import" 
   --data-binary @registry-export.zip
 ```
 
-3 - Check that all the artifacts are now imported to the new 2.x registry. Run these two commands and compare the count field.
+3. Check that all the artifacts are now imported to the new 2.x registry. Run these two commands and compare the count field.
 
 ```
 curl "http://old-registry.my-company.com/api/search/artifacts"
@@ -76,9 +75,9 @@ curl "http://new-registry.my-company.com/apis/registry/v2/search/artifacts"
 
 ### Application Migration
 
-If you are using the Apicurio Registry SerDes libraries, you need to change the maven dependencies you are using, as we have repackaged these classes.
+If you are using the Apicurio Registry SerDes libraries, you need to change the Maven dependencies you are using, as we have repackaged these classes.
 
-In Apicurio Registry 1.3.x the SerDes libraries were provided all with just one maven dependency:
+In Apicurio Registry 1.3.x the SerDes libraries were provided all with just one Maven dependency:
 ```
 <dependency>
     <groupId>io.apicurio</groupId>
@@ -87,7 +86,7 @@ In Apicurio Registry 1.3.x the SerDes libraries were provided all with just one 
 </dependency>
 ```
 
-In Apicurio Registry 2.x this has been changed, and the SerDes libraries have been split into three maven dependencies, one for each supported data format: `avro`, `protobuf` and `json schema`.
+In Apicurio Registry 2.x this has been changed, and the SerDes libraries have been split into three Maven dependencies, one for each supported data format: `avro`, `protobuf` and `json schema`.
 
 ```
 <dependency>
@@ -107,11 +106,11 @@ In Apicurio Registry 2.x this has been changed, and the SerDes libraries have be
 </dependency>
 ```
 
-You have to take into account this changes in the maven dependencies, and update your applications accordingly.
+You must take into account these changes to Maven dependencies, and update your applications accordingly.
 
-The refactored SerDes libraries also include some changes in the configuration properties, you can find more information [here](https://www.apicur.io/registry/docs/apicurio-registry/2.0.0.Final/getting-started/assembly-using-kafka-client-serdes.html) , and you can find plenty of examples using Apicurio Registry 2.0.0.Final SerDes libraries [here](https://github.com/Apicurio/apicurio-registry-examples/tree/2.0.x)
+The refactored SerDes libraries also include some changes in the configuration properties. You can find more details in the [Apicurio Registry user documentation](https://www.apicur.io/registry/docs/apicurio-registry/2.0.0.Final/getting-started/assembly-using-kafka-client-serdes.html) , and you can find plenty of examples using Apicurio Registry 2.0.0.Final SerDes libraries [here](https://github.com/Apicurio/apicurio-registry-examples/tree/2.0.x)
 
-But the most important thing you have to change is the registry url config property, you have to change from pointing to the old API path to the new one. Example:
+But the most important thing you must change is the registry URL configuration, which you must change from pointing to the existing API path to the new one. For example:
 
 Old:
 ```

--- a/_posts/2021-06-01-migration-v1-v2.md
+++ b/_posts/2021-06-01-migration-v1-v2.md
@@ -6,56 +6,56 @@ author: fabian
 categories: registry guide
 ---
 
-Apicurio Registry 2.x release is our latest and greatest release to date. It has plenty new features but it also comes with some breaking changes from the previous
-1.3.X release. In this document we explore the process to migrate to Apicurio Registry 2.X
+Apicurio Registry 2.x release is our latest and greatest release to date. It has plenty of new features but it also comes with some breaking changes from the previous
+1.3.x release. In this post we will explore the process to migrate data from Apicurio Registry 1.3.x to Apicurio Registry 2.x.
 
 ---
 
 # Apicurio Registry 2.0.0.Final Migration Guide
 
-Apicurio Registry 2.x release is our latest and greatest release to date. It has plenty new features but it also comes with some breaking changes from the previous
-1.3.X release.
-
-Because of the breaking changes there is no automatic upgrade and instead a migration process is required, but no worries, the process is not hard.
+Because of the breaking changes between 1.3.x and 2.x, there is no automatic upgrade and instead a migration process is required.  But don't worry!  We promise the process is not hard.
 
 ## Breaking changes
 
-There are three major changes in this release that need to be taken into account in order to proceed with a migration. 
+There are three major changes in this release that need to be taken into account in order to proceed with a migration.
 
-New storage options, this impacts your current Apicurio Registry deployment. In Apicurio Registry 1.3.X we had 3 storage options (streams, jpa and infinispan), now in
-Apicurio Registry 2.X we droped all of them but provided new and improved alternatives that we believe will be better for the project in the long term, allowing to have more robust and performant deployments while at the same time being reasonabily maintainable. The new storage options are (sql and kafkasql), there is a third one (mem) that is not suitable for production workloads. This document will not cover the process of deploying Apicurio Registry 2.X, you can find more information [here](https://www.apicur.io/registry/docs/apicurio-registry/2.0.0.Final/getting-started/assembly-installing-registry-storage-openshift.html)
+### New storage options
+This impacts your current Apicurio Registry deployment. In Apicurio Registry 1.3.x we had 3 storage options (streams, jpa and infinispan).  Now in
+Apicurio Registry 2.x we dropped all of them but provided new and improved alternatives that we believe will be better for the project in the long term.  These new storages allow for more robust and performant deployments while at the same time being more maintainable. The new storage options are `sql` and `kafkasql`).  There is a third one `mem` that is not suitable for production workloads. This document will not cover the process of deploying Apicurio Registry 2.x, you can find more information [here](https://www.apicur.io/registry/docs/apicurio-registry/2.0.0.Final/getting-started/assembly-installing-registry-storage-openshift.html)
 
-New REST API, we changed the REST API layout to ensure better long term maintainability and because we refactored our API to have support for artifact groupings. Apicurio Registry still supports the original REST API now known as `v1` and the various compatibility APIs we already support (confluent compat, ibm compat) and a new API that implements the Schema Registry spec provided within CNCF Cloud Events spec.
+### New REST API
+We changed the REST API layout to ensure better long term maintainability and because we refactored our API to have support for artifact groupings. Apicurio Registry still supports the original REST API (now known as `v1`) and the various compatibility APIs we already supported (confluent compat, ibm compat).  Additionally, Registry now also implements the Schema Registry spec provided within the CNCF Cloud Events spec.
 
-Refactored SerDes libraries, now available as three different maven modules (one for each data format)
+### Refactored SerDes libraries
+The Serializer and Deserializer classes are now available as three different maven modules (one for each data format).  This makes it possible to use just the one you want without pulling in a bunch of transitive dependencies that you don't care about.
 
 ## Migration
 
-The migration from Apicurio Registry 1.3.X to 2.X requires you to move the data from one registry to another along with a review of your applications that interact with the registry in order to update the configuration of your applications to accomadate to the new requirements.
+The migration from Apicurio Registry 1.3.x to 2.x requires you to move the data from your old registry to another along with a review of your applications that interact with the registry in order to update the configuration of your applications to accomadate to the new requirements.
 
 ### Data Migration
 
-The process of data migration to Apicurio Registry 2.X will require you to export all the data from your 1.3.X deployment and import it to the new 2.X based deployment.
+The process of data migration to Apicurio Registry 2.x will require you to export all the data from your 1.3.x deployment and import it to the new 2.x based deployment.
 
-Data migration is a critical step in the migration to Apicurio Registry 2.X if you are using the registry as a schema registry for Kafka applications and if you are using our Kafka SerDes libraries, every kafka message carries the global identifier for the schema stored in Apicurio Registry. It's critical that this identifier is kept between registry upgrades and data migrations.
+Data migration is a critical step in the migration to Apicurio Registry 2.x if you are using the registry as a schema registry for Kafka applications, because every Kafka message carries the global identifier for the schema stored in Apicurio Registry. It is critical that this identifier is kept between registry upgrades via data migration.
 
-For that purpose Apicurio Registry 2.X provides a new import/export API to bulk import or export all the data from your registry deployment. This API guarantees that all the identifiers are kept when importing the data from your old registry. The export API works by downloading a custom zip file containing all the information of your artifacts. The import API accepts that zip file.
+For that purpose Apicurio Registry 2.x provides a new import/export API to bulk import or export all the data from your registry deployment. This API guarantees that all the identifiers are kept when importing the data from your old registry. The export API works by downloading a custom zip file containing all the information of your artifacts. The import API accepts that zip file, loading all of the artifacts into the registry in a single batch.
 
-Apicurio Registry 1.3.X does not provide an import/export API but with the 2.X release we provided a export tool compatible with Apicurio Registry 1.3.X that allows you to export a zip file which then can be imported to your 2.X registry.
+Apicurio Registry 1.3.x does not provide an import/export API but with the 2.x release we provided an export tool compatible with Apicurio Registry 1.3.x that allows you to export a compatible zip file which then can be imported to your 2.x registry.  This special export tool uses common existing APIs to export all of the content in the registry.  It is less performant than the built-in export API we have introduced in 2.x, and so should only be used when exporting from a 1.3.x registry.
 
 This export tool can be found [here](https://github.com/Apicurio/apicurio-registry/tree/2.0.x/utils/exportV1). It is a java application meant to be invoked from the command line.
 
-The migration steps for moving all your data from one version to another would be like this:
+The migration steps for moving all your data from one version to another:
 
-**Pre-requisites**: having both a running Apicurio Registry instance for the version 1.3.X and 2.X.
+**Pre-requisites**: having running Apicurio Registry instances for both the version 1.3.x server (exporting from) and the new 2.x server (importing to).
 
-1 - Export all the data from Apicurio Registry 1.3.X using the `exportV1` tool. This will generate a `registry-export.zip` file in your current directory.
+1. Export all the data from Apicurio Registry 1.3.x using the `exportV1` tool. This will generate a `registry-export.zip` file in your current directory.
 
 ```
 java -jar apicurio-registry-utils-exportV1-2.0.0-SNAPSHOT-runner.jar http://old-registry.my-company.com/api
 ```
 
-2 - Import the zip file to Apicurio Registry 2.X using the import API. Extended documentation on this API can be found [here](https://www.apicur.io/registry/docs/apicurio-registry/2.0.0.Final/getting-started/assembly-managing-registry-artifacts-api.html#exporting-importing-using-rest-api)
+2 - Import the zip file to Apicurio Registry 2.x using the import API. Extended documentation on this API can be found [here](https://www.apicur.io/registry/docs/apicurio-registry/2.0.0.Final/getting-started/assembly-managing-registry-artifacts-api.html#exporting-importing-using-rest-api)
 
 ```
 curl -X POST "http://new-registry.my-company.com/apis/registry/v2/admin/import" \
@@ -63,7 +63,7 @@ curl -X POST "http://new-registry.my-company.com/apis/registry/v2/admin/import" 
   --data-binary @registry-export.zip
 ```
 
-3 - Check the all the artifacts are now imported to the newest registry. Run this two commands and compare the count field.
+3 - Check that all the artifacts are now imported to the new 2.x registry. Run these two commands and compare the count field.
 
 ```
 curl "http://old-registry.my-company.com/api/search/artifacts"
@@ -76,9 +76,9 @@ curl "http://new-registry.my-company.com/apis/registry/v2/search/artifacts"
 
 ### Application Migration
 
-TL.DR. if you are using the SerDes libraries, you need to change the maven dependencies
+If you are using the Apicurio Registry SerDes libraries, you need to change the maven dependencies you are using, as we have repackaged these classes.
 
-In Apicurio Registry 1.3.X the SerDes libraries were provided all with just one maven dependency
+In Apicurio Registry 1.3.x the SerDes libraries were provided all with just one maven dependency:
 ```
 <dependency>
     <groupId>io.apicurio</groupId>
@@ -87,7 +87,7 @@ In Apicurio Registry 1.3.X the SerDes libraries were provided all with just one 
 </dependency>
 ```
 
-In Apicurio Registry 2.X this has been changed, and the SerDes libraries have been splitted in three maven dependencies, one for each supported data format: `avro`, `protobuf` and `json schema`.
+In Apicurio Registry 2.x this has been changed, and the SerDes libraries have been split into three maven dependencies, one for each supported data format: `avro`, `protobuf` and `json schema`.
 
 ```
 <dependency>
@@ -125,6 +125,6 @@ props.putIfAbsent(SerdeConfig.REGISTRY_URL, "http://localhost:8080/apis/registry
 
 ---
 
-This is the most important things to take into account when doing the update to Apicurio Registry 2.0.0.Final. The process is not complex but there are some critical steps that, thanks to our APIs and tooling, should be no problem.
+These are the most important things to take into account when doing the update to Apicurio Registry 2.0.0.Final. The process is not complex but there are some critical steps that, thanks to our APIs and tooling, should be no problem.
 
 As always, if you have any suggestions or encounter any problem feel free to contact the team by [filling an issue in GitHub](https://github.com/Apicurio/apicurio-registry/issues)


### PR DESCRIPTION
This is the initial version of the migratino guide post with migration instructions for the update from Apicurio Registry 1.3.x to 2.x

There are probably some wording issues, that's why I send this for review mainly.

The exportV1 tool is not available, I'm going to work on a GH workflow to include it in the 2.0.0.Final githuib release