### PR TITLE
add api docs to nav

### DIFF
--- a/_includes/registry/_projnav.html
+++ b/_includes/registry/_projnav.html
@@ -28,6 +28,12 @@
         </a>
     </li>
     <li>
+        <a href="{{ site.baseurl }}/registry/docs/apicurio-registry/3.0.x/assets-attachments/registry-rest-api.htm">
+            <span>API Docs</span>
+            <i class="fa fa-book" aria-hidden="true"></i>
+        </a>
+    </li>
+    <li>
         <a href="{{ site.github_registry_url }}/issues">
             <span>Issue Tracker</span>
             <i class="fa fa-bug" aria-hidden="true"></i>


### PR DESCRIPTION
Api docs are more important in v3 if folks deploy only backend
Not sure if this implements the change correctly?