### PR TITLE
fix: migrate support chat widget to Hugging Face Spaces

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,4 +23,4 @@
 </div>
 
 <!-- Apicurio Registry AI Support Chat Widget -->
-<script src="https://apicurio-support-chat.onrender.com/chat-widget.js"></script>
+<script src="https://carnalca-apicurio-support-chat.hf.space/chat-widget.js"></script>


### PR DESCRIPTION
## Summary
- Update the AI support chat widget script URL from Render.com to Hugging Face Spaces
- Render free tier was failing due to image pull limits; HF Spaces provides more resources for free

## Changes
- `_includes/footer.html`: Update script src from `apicurio-support-chat.onrender.com` to `carnalca-apicurio-support-chat.hf.space`

## Test plan
- [ ] Verify the HF Space is running: https://carnalca-apicurio-support-chat.hf.space
- [ ] Verify chat widget loads on the site
- [ ] Test a chat interaction through the widget