### PR TITLE
fix: update CSP to allow HF Spaces for support chat widget

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
   <meta http-equiv="Referrer-Policy" content="no-referrer, strict-origin-when-cross-origin">
 
   <meta http-equiv='Content-Security-Policy'
-  content="default-src https://www.youtube.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' https://static.jboss.org https://www.google-analytics.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' https://maxcdn.bootstrapcdn.com https://www.google-analytics.com https://cdnjs.cloudflare.com https://www.apicurio.io https://www.googletagmanager.com https://apicurio-support-chat.onrender.com; connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com https://apicurio-support-chat.onrender.com; base-uri 'none'; form-action 'none';">
+  content="default-src https://www.youtube.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' https://static.jboss.org https://www.google-analytics.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' https://maxcdn.bootstrapcdn.com https://www.google-analytics.com https://cdnjs.cloudflare.com https://www.apicurio.io https://www.googletagmanager.com https://carnalca-apicurio-support-chat.hf.space; connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com https://carnalca-apicurio-support-chat.hf.space; base-uri 'none'; form-action 'none';">
 
   <link rel="shortcut icon" href="{{ site.baseurl }}/images/favicon.ico" type="image/x-icon" integrity="sha384-if9KH+NQ2dMhdrWu+INnJTcvG6riRakUAnbhecX5a7voubrapo7ouFGS+GYZ/N4P" crossorigin="anonymous"/>
 


### PR DESCRIPTION
## Summary
- Update Content Security Policy in `head.html` to allow the Hugging Face Spaces domain (`carnalca-apicurio-support-chat.hf.space`) instead of the Render.com domain
- Applies to both `script-src` and `connect-src` directives
- Required after migrating the support chat hosting from Render to HF Spaces (PR #106)

## Test plan
- [ ] Verify chat widget loads without CSP errors on the site
- [ ] Verify chat API calls succeed (connect-src)