### PR TITLE
Add blog post for Apicurio Registry 3.3.0 release

### DIFF
--- a/_posts/2026-06-16-registry-3.3.0-released.md
+++ b/_posts/2026-06-16-registry-3.3.0-released.md
@@ -1,0 +1,110 @@
+---
+layout: post
+title: "Apicurio Registry 3.3.0 Released"
+date: 2026-06-16 12:00:00
+author: carles
+categories: registry release
+---
+
+We are excited to announce the release of **Apicurio Registry 3.3.0**! This is a major feature release that introduces Data Contracts support, a completely revamped CLI experience, Kubernetes Operator improvements, and much more. Read on for the highlights.
+
+---
+
+# Data Contracts
+
+The headline feature of 3.3.0 is the introduction of **Data Contracts** — a comprehensive framework for defining, enforcing, and governing the quality and structure of your data artifacts.
+
+## ODCS (Open Data Contract Standard) Support
+
+Apicurio Registry now supports the **Open Data Contract Standard v3.1**, including a full parser, a projection engine for extracting relevant views from contracts, REST API endpoints for managing contracts, the ability to export contracts from existing artifacts, and first-class artifact type registration.
+
+## Tags
+
+A new tagging system allows metadata to be automatically extracted from your schemas. Tag extractors are available for **Avro**, **JSON Schema**, and **Protobuf**, with a pluggable SPI so you can add your own. Tags are stored alongside artifacts and are fully queryable through the API.
+
+## Contract Rules and Governance
+
+Data contracts can now include **rules** that define quality and governance constraints. A new **CEL (Common Expression Language) Rule Executor** allows you to write powerful, flexible rules that are evaluated at runtime. The governance rule type provides a structured way to enforce organizational policies around data quality.
+
+## Quality Score and Promotion Workflow
+
+A built-in **Quality Score Calculator** evaluates artifacts against their contract rules and produces a score, giving you a quantitative measure of data quality. Combined with the new **Promotion Workflow**, you can define stage gates that artifacts must pass through — for example, requiring a minimum quality score before an artifact can be promoted from `draft` to `production`.
+
+## Contract REST API
+
+All of this is exposed through dedicated **Contract REST API endpoints**, complete with metadata models and label conventions for consistent organization.
+
+---
+
+# CLI
+
+The Apicurio Registry CLI has been significantly enhanced in this release, graduating from its initial MVP to a fully-featured management tool.
+
+## New Capabilities
+
+- **Search** — Find groups, artifacts, and versions directly from the command line
+- **Full CRUD management** — Create, read, update, and delete groups, artifacts, versions, and rules (global, group-level, and artifact-level)
+- **Version comments** — Add and manage comments on artifact versions
+- **Context management** — Create, update, and switch between CLI contexts for managing multiple registry instances
+- **Draft content updates** — Update the content of draft versions directly
+- **Authentication** — Support for both Basic auth and OAuth2
+
+## Quality of Life
+
+- **Automatic updates** with OS and architecture detection
+- **Verbose mode** now properly controls Quarkus/JBoss logging output
+- Improved error handling with simplified `ProblemDetails` and proper `RuleViolationProblemDetails` support
+- Internal conversion to CDI for better modularity
+
+---
+
+# Operator Improvements
+
+The Apicurio Registry Operator now supports **Horizontal Pod Autoscaler (HPA)** for both the application and UI deployments, making it easier to scale your registry in Kubernetes environments. Additionally, the operator now **auto-creates RBAC resources** when using KubernetesOps storage, simplifying deployment configuration.
+
+---
+
+# UI Improvements
+
+The Registry UI now supports adding **artifact references** when registering new artifacts or versions, making it possible to define schema hierarchies directly from the web interface.
+
+---
+
+# MCP Tool Definition Artifact Type
+
+A new **MCP Tool Definition** artifact type has been added, allowing you to store and manage Model Context Protocol tool definitions as first-class artifacts in the registry. This further extends our [AI-native capabilities]({{ site.baseurl }}{% post_url 2026-02-05-apicurio-registry-ai-natural-evolution %}).
+
+---
+
+# API Lifecycle Governance
+
+This release introduces **API Lifecycle Governance** capabilities covering deprecation management, consumer tracking, and impact analysis. This gives you visibility into who is consuming your APIs and helps you manage the full lifecycle from introduction to retirement.
+
+---
+
+# Bug Fixes
+
+Several important bugs have been fixed in this release:
+
+- Confluent compatibility endpoint now correctly resolves versions by integer sequence number when artifacts use semantic versioning
+- Retry handler properly fires retries for `HttpClosedException`
+- Kafka topic cleanup policy documentation corrected
+- Fixed `NullPointerException` in `JsonSchemaContentValidator` when references are missing
+- Fixed Avro schema references to pre-defined enum types
+- Hardened Protobuf validation against malformed identifiers and conflicting FQNs
+- Various Confluent compatibility improvements identified by the compatibility harness
+
+---
+
+# Try It Out
+
+You can get started with Apicurio Registry 3.3.0 right away:
+
+```
+docker pull quay.io/apicurio/apicurio-registry:3.3.0
+docker run -it -p 8080:8080 quay.io/apicurio/apicurio-registry:3.3.0
+```
+
+Check out the full release notes on [GitHub](https://github.com/Apicurio/apicurio-registry/releases/tag/3.3.0).
+
+As always, we welcome your feedback and contributions. Feel free to open an issue on [GitHub](https://github.com/Apicurio/apicurio-registry/issues) or join the community discussion.


### PR DESCRIPTION
## Summary
- Adds a new blog post announcing the Apicurio Registry 3.3.0 release
- Covers key highlights: Data Contracts (ODCS, tags, rules, quality scoring, promotion workflow), revamped CLI, Operator HPA support, UI improvements, MCP Tool Definition artifact type, API Lifecycle Governance, and bug fixes
- Content based on the [GitHub release notes](https://github.com/Apicurio/apicurio-registry/releases/tag/3.3.0)

## Test plan
- [ ] Verify blog post renders correctly on the site
- [ ] Check all links work properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)