### PR TITLE
chore: replace Red Hat branding with CNCF/LF Projects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,9 +14,7 @@ github_codegen_url: https://github.com/Apicurio/apicurio-codegen
 docker_hub_url: https://hub.docker.com/r/apicurio
 apitomy_url: https://www.apitomy.io
 try_now_url: https://studio.apicur.io/
-mas_registry_url: https://console.redhat.com/application-services/service-registry
-mas_cli_url: https://github.com/redhat-developer/app-services-cli/releases
-email: apiman-user@lists.jboss.org
+email: apicurio@lists.cncf.io
 future: true
 quickstart: true
 excerpt_separator: '---'

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,15 +6,17 @@
                 <div class="widget col-sm-6 col-md-6 widget_text">
                     <div class="textwidget">
                         <p>
-                            Copyright © 2023 Red Hat, Inc. All rights reserved.<br>
+                            Copyright Apicurio Registry a Series of LF Projects, LLC.<br>
+                            For web site terms of use, trademark policy and other project policies please see
+                            <a href="https://lfprojects.org/policies/" rel="nofollow" target="_blank">lfprojects.org/policies/</a>.<br>
                             Code is open source and released under <a href="https://www.apache.org/licenses/LICENSE-2.0.html" rel="nofollow"
                                                                       target="_blank">Apache License, v2.0</a>.<br>
                         </p>
                     </div>
                 </div>
                 <div class="widget col-sm-6 col-md-6 widget_text footer-logo">
-                    <a href="https://www.redhat.com" rel="nofollow" target="_blank"><img
-                            src="https://static.jboss.org/theme/images/common/redhat_logo.png" alt="Red Hat"></a>
+                    <a href="https://www.cncf.io" rel="nofollow" target="_blank"><img
+                            src="https://www.cncf.io/wp-content/uploads/2022/07/cncf-color-bg.svg" alt="Cloud Native Computing Foundation" style="max-height: 50px;"></a>
                 </div>
             </div>
             <nav class="clearfix"></nav>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,13 +8,12 @@
   <meta http-equiv="Referrer-Policy" content="no-referrer, strict-origin-when-cross-origin">
 
   <meta http-equiv='Content-Security-Policy'
-  content="default-src https://www.youtube.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' https://static.jboss.org https://www.google-analytics.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' https://maxcdn.bootstrapcdn.com https://www.google-analytics.com https://cdnjs.cloudflare.com https://www.apicurio.io https://www.googletagmanager.com https://carnalca-apicurio-support-chat.hf.space; connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com https://carnalca-apicurio-support-chat.hf.space; base-uri 'none'; form-action 'none';">
+  content="default-src https://www.youtube.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' https://www.cncf.io https://www.google-analytics.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' https://maxcdn.bootstrapcdn.com https://www.google-analytics.com https://cdnjs.cloudflare.com https://www.apicurio.io https://www.googletagmanager.com https://carnalca-apicurio-support-chat.hf.space; connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com https://carnalca-apicurio-support-chat.hf.space; base-uri 'none'; form-action 'none';">
 
   <link rel="shortcut icon" href="{{ site.baseurl }}/images/favicon.ico" type="image/x-icon" integrity="sha384-if9KH+NQ2dMhdrWu+INnJTcvG6riRakUAnbhecX5a7voubrapo7ouFGS+GYZ/N4P" crossorigin="anonymous"/>
 
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.59.2/css/patternfly.min.css" integrity="sha256-rLJV3jlFRU38RbS+z4Ee+xgtP71nt4Tg+d1OTGmnJkw=" crossorigin="anonymous" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.59.2/css/patternfly-additions.min.css" integrity="sha256-PBAEJlhJ/tR8v9h+haGuRcMU0RzFsbOCXxpeRbe5X6Y=" crossorigin="anonymous" />
-  <link rel="stylesheet" href="{{ site.baseurl }}/css/rhbar.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/css/index.css">
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.js" integrity="sha256-iT6Q9iMJYuQiMWNd9lDyBUStIq/8PuOW33aOqmvFpqI=" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary

Per CNCF staff request on [cncf/sandbox#495](https://github.com/cncf/sandbox/issues/495), scrub Red Hat branding and update footer to LF Projects format.

Changes:
- **Footer**: Replace "Copyright © 2023 Red Hat, Inc." with LF Projects copyright and link to lfprojects.org/policies/
- **Footer logo**: Replace Red Hat logo with CNCF logo
- **Config**: Remove unused `mas_registry_url` and `mas_cli_url` (Red Hat console links), update email from `apiman-user@lists.jboss.org` to `apicurio@lists.cncf.io`
- **CSP header**: Replace `static.jboss.org` with `www.cncf.io` in img-src
- **CSS**: Remove unused `rhbar.css` reference (Red Hat branded top bar)

Note: The `registry/maven-plugin/` pages also contain Red Hat references but those are auto-generated by Maven site plugin and should be regenerated separately.