### PR TITLE
Make the site header responsive and stop the homepage overflowing

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,6 +4,12 @@
             <a href="{{site.baseurl}}/"><img src="{{site.baseurl}}/images/apicurio_headerlogo.png" class="project-logo" title="Apicurio"></a>
         </div>
 
+        <button id="nav-toggle" class="nav-toggle" type="button" aria-controls="main-nav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="nav-toggle-bar"></span>
+            <span class="nav-toggle-bar"></span>
+            <span class="nav-toggle-bar"></span>
+        </button>
+
         <nav id="main-nav" class="main-nav">
             <ul id="menu" class="menu">
                 <li>

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -1,27 +1,51 @@
+$masthead-collapse-width: 1024px;
+
 .masthead-container {
 
   width: 100%;
   background-color: rgb(35, 31, 32);
-  height: 96px;
   text-align: center;
   display: flex;
   justify-content: center;
 
   .masthead {
 
-    width: 1180px;
-    height: 96px;
+    width: 100%;
+    max-width: 1180px;
+    min-height: 96px;
+    padding: 0 20px;
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
 
-    @media screen and (max-width: 1024px) {
-    }
-
     .logo {
       width: 294px;
-      flex-shrink: 0;
+      max-width: 65%;
       margin-right: 20px;
+
+      .project-logo {
+        max-width: 100%;
+      }
+    }
+
+    .nav-toggle {
+      display: none;
+      width: 44px;
+      height: 44px;
+      padding: 10px;
+      background: none;
+      border: none;
+
+      .nav-toggle-bar {
+        display: block;
+        height: 2px;
+        background-color: white;
+
+        + .nav-toggle-bar {
+          margin-top: 5px;
+        }
+      }
     }
 
     .main-nav {
@@ -54,6 +78,45 @@
 
         li.nav-divider {
           border-left: 1px solid #ccc;
+        }
+
+      }
+
+    }
+
+    @media screen and (max-width: $masthead-collapse-width) {
+
+      .nav-toggle {
+        display: block;
+      }
+
+      .main-nav {
+        flex: 0 0 100%;
+        order: 1;
+        display: none;
+
+        &.is-open {
+          display: block;
+        }
+
+        .menu {
+          display: block;
+          text-align: left;
+          padding-bottom: 10px;
+
+          li {
+            margin-left: 0;
+            a {
+              display: block;
+              padding: 12px 0;
+            }
+          }
+
+          li.nav-divider {
+            border-left: none;
+            border-top: 1px solid #ccc;
+          }
+
         }
 
       }

--- a/_sass/_homepage-subproject-band.scss
+++ b/_sass/_homepage-subproject-band.scss
@@ -12,6 +12,10 @@
 .contrib-block {
   padding-top: 8rem;
 
+  img {
+    max-width: 100%;
+  }
+
   @media screen and (max-width: 993px) {
     width: 100%;
     padding-top: 4rem;
@@ -21,12 +25,17 @@
 .logo-with-badge {
   position: relative;
   display: inline-block;
+  max-width: 100%;
 }
 
 .deprecated-badge {
   position: absolute;
   top: -8px;
   right: -32px;
+
+  @media screen and (max-width: 993px) {
+    right: 0;
+  }
   background-color: #dc3545;
   color: white;
   padding: 4px 10px;
@@ -40,6 +49,11 @@
   position: absolute;
   top: -8px;
   right: -32px;
+
+  @media screen and (max-width: 993px) {
+    right: 0;
+  }
+
   background-color: #fd7e14;
   color: white;
   padding: 4px 10px;

--- a/js/index.js
+++ b/js/index.js
@@ -20,9 +20,24 @@ function fixSyntaxHighlighting () {
 }
 
 
+// Show and hide the collapsed navigation menu on narrow viewports
+function initNavToggle () {
+  var toggle = document.getElementById('nav-toggle');
+  var nav = document.getElementById('main-nav');
+  if (!toggle || !nav) {
+    return;
+  }
+  toggle.addEventListener('click', function () {
+    var isOpen = nav.classList.toggle('is-open');
+    toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  });
+}
+
+
 document.addEventListener('DOMContentLoaded', function () {
   fixPlatformLabels();
   fixSyntaxHighlighting();
+  initNavToggle();
 });
 
 


### PR DESCRIPTION
Fixes #129.

The masthead had a fixed `width: 1180px` and no mobile styles, so the logo was cut off and unreachable below about 1220px. The homepage also scrolled sideways because the subproject logos had no width cap.

### Changes

- `_sass/_header.scss`: `max-width` instead of `width`, `min-height` instead of `height`, and the empty 1024px breakpoint now collapses the nav.
- `_includes/header.html`: added a toggle button with `aria-controls`, `aria-expanded` and `aria-label`.
- `js/index.js`: `initNavToggle()` wired into the existing `DOMContentLoaded` handler. No inline script, since the page CSP is `script-src 'self'`.
- `_sass/_homepage-subproject-band.scss`: `max-width: 100%` on the logos, and the badges move to `right: 0` below 993px.

CSS only plus one button. No new dependencies.

### Testing

Checked with the DevTools Protocol at 320, 375, 414, 768, 993, 1024, 1180 and 1280px, on all 11 page templates.

- The header does not overflow at any width.
- The logo stays on screen at any width.
- The toggle shows below 1024px and hides above it.
- Clicking it opens and closes the menu and updates `aria-expanded`. All 8 links fit inside the viewport when open.
- Homepage horizontal overflow is 0 at every width. It was 190px at 320px and 135px at 375px.
- Desktop rendering is unchanged, including the logo sizes and the badge offsets.

### Screenshot

<img width="376" height="668" alt="image" src="https://github.com/user-attachments/assets/beb96150-78e1-46f4-ad7a-08937de88304" />

